### PR TITLE
feat: 로그인 및 멤버 관련 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ secrets.yml
 .idea
 .env
 src/test/resources/application.yml
+src/main/resources/application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,15 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+	// jwt
+	implementation "org.springframework.boot:spring-boot-starter-security"
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/ceos/vote/VoteApplication.java
+++ b/src/main/java/ceos/vote/VoteApplication.java
@@ -2,8 +2,10 @@ package ceos.vote;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class VoteApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/ceos/vote/domain/member/controller/AuthController.java
+++ b/src/main/java/ceos/vote/domain/member/controller/AuthController.java
@@ -1,0 +1,50 @@
+package ceos.vote.domain.member.controller;
+
+import ceos.vote.domain.member.dto.request.SignupRequestDto;
+import ceos.vote.domain.member.dto.response.MemberResponseDto;
+import ceos.vote.domain.member.service.AuthService;
+import ceos.vote.global.common.response.CommonResponse;
+import ceos.vote.global.jwt.JWTUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Tag(name = "Auth", description = "인증 관련 API")
+public class AuthController {
+
+    private final AuthService authService;
+    private final JWTUtil jwtUtil;
+
+    @PostMapping("/signup")
+    @Operation(summary = "회원가입", description = "회원가입 요청 API")
+    public CommonResponse<MemberResponseDto> signup(@Valid @RequestBody SignupRequestDto request) {
+
+        return new CommonResponse<>(authService.signup(request), "회원가입을 성공하였습니다.");
+    }
+
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급", description = "토큰 재발급 요청 API")
+    public CommonResponse<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
+
+        String refreshToken = authService.extractRefreshToken(request);
+        authService.validateRefreshToken(refreshToken);
+
+        String newAccessToken = authService.reissueAccessToken(refreshToken);
+        Cookie RefreshTokenCookie = authService.createRefreshTokenCookie(refreshToken);
+
+        authService.setNewTokens(response, newAccessToken, RefreshTokenCookie);
+
+        return new CommonResponse<>("토큰 재발급을 성공하였습니다.");
+    }
+}

--- a/src/main/java/ceos/vote/domain/member/controller/MemberController.java
+++ b/src/main/java/ceos/vote/domain/member/controller/MemberController.java
@@ -1,0 +1,31 @@
+package ceos.vote.domain.member.controller;
+
+import ceos.vote.domain.member.dto.CustomUserDetails;
+import ceos.vote.domain.member.dto.response.MemberResponseDto;
+import ceos.vote.domain.member.service.MemberService;
+import ceos.vote.global.common.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/member")
+@RequiredArgsConstructor
+@Tag(name = "Member", description = "회원 관련 API")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "회원 기본 정보 조회", description = "회원의 기본 정보를 조회하는 API")
+    @GetMapping
+    public CommonResponse<MemberResponseDto> getMemberInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long memberId = userDetails.getMemberId();
+
+        return new CommonResponse<>(memberService.getMemberInfo(memberId), "회원 기본 정보 조회를 성공하였습니다.");
+    }
+}

--- a/src/main/java/ceos/vote/domain/member/dto/CustomUserDetails.java
+++ b/src/main/java/ceos/vote/domain/member/dto/CustomUserDetails.java
@@ -1,0 +1,72 @@
+package ceos.vote.domain.member.dto;
+
+import ceos.vote.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+
+            @Override
+            public String getAuthority() {
+                return member.getRole();
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+
+        return member.getUserId();
+    }
+
+    public Long getMemberId() {
+
+        return member.getId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return true;
+    }
+}

--- a/src/main/java/ceos/vote/domain/member/dto/request/LoginRequestDto.java
+++ b/src/main/java/ceos/vote/domain/member/dto/request/LoginRequestDto.java
@@ -1,11 +1,15 @@
 package ceos.vote.domain.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public record LoginRequestDto(
 
+        @Schema(description = "아이디", example = "ceos2024")
         @NotNull
         String userId,
+
+        @Schema(description = "비밀번호", example = "12345678")
         @NotNull
         String password
 ) {

--- a/src/main/java/ceos/vote/domain/member/dto/request/LoginRequestDto.java
+++ b/src/main/java/ceos/vote/domain/member/dto/request/LoginRequestDto.java
@@ -1,0 +1,12 @@
+package ceos.vote.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record LoginRequestDto(
+
+        @NotNull
+        String userId,
+        @NotNull
+        String password
+) {
+}

--- a/src/main/java/ceos/vote/domain/member/dto/request/SignupRequestDto.java
+++ b/src/main/java/ceos/vote/domain/member/dto/request/SignupRequestDto.java
@@ -1,0 +1,53 @@
+package ceos.vote.domain.member.dto.request;
+
+import ceos.vote.domain.member.entity.Member;
+import ceos.vote.domain.member.entity.PartType;
+import ceos.vote.domain.member.entity.TeamType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequestDto(
+
+        @Schema(description = "이름", example = "홍길동")
+        @NotNull(message = "이름은 필수 입력 사항입니다.")
+        String name,
+
+        @Schema(description = "아이디", example = "ceos2024")
+        @NotNull(message = "아이디는 필수 입력 사항입니다.")
+        String userId,
+
+        @Schema(description = "비밀번호", example = "12345678")
+        @NotNull(message = "비밀번호는 필수 입력 사항입니다.")
+        String password,
+
+        @Schema(description = "이메일", example = "ceos@gmail.com")
+        @Email(message = "유효한 이메일 주소를 입력해주세요.")
+        String email,
+
+        @Schema(description = "소속 팀명", example = "포토그라운드 | 엔젤브릿지 | 페달지니 | 케이크웨이 | 커피딜")
+        @NotNull(message = "소속 팀명은 필수 입력 사항입니다.")
+        String team,
+
+        @Schema(description = "소속 파트", example = "프론트엔드 | 백엔드")
+        @NotNull(message = "소속 파트는 필수 입력 사항입니다.")
+        String part
+) {
+    public Member toEntity(String encodedPassword, PartType part, TeamType team) {
+        return Member.builder()
+                .userId(userId)
+                .password(encodedPassword)
+                .email(email)
+                .role("ROLE_USER")
+                .part(part)
+                .name(name)
+                .team(team)
+                .voteBack(false)
+                .voteFront(false)
+                .voteTeam(false)
+                .build();
+    }
+}
+

--- a/src/main/java/ceos/vote/domain/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/ceos/vote/domain/member/dto/response/MemberResponseDto.java
@@ -1,0 +1,30 @@
+package ceos.vote.domain.member.dto.response;
+
+import ceos.vote.domain.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record MemberResponseDto (
+
+        String userId,
+        String name,
+        String email,
+        String team,
+        String part,
+        Boolean voteBack,
+        Boolean voteFront,
+        Boolean voteTeam
+) {
+    public static MemberResponseDto from(Member member) {
+        return MemberResponseDto.builder()
+                .userId(member.getUserId())
+                .name(member.getName())
+                .email(member.getEmail())
+                .team(member.getTeam().getDescription())
+                .part(member.getPart().getDescription())
+                .voteBack(member.getVoteBack())
+                .voteFront(member.getVoteFront())
+                .voteTeam(member.getVoteTeam())
+                .build();
+    }
+}

--- a/src/main/java/ceos/vote/domain/member/entity/Member.java
+++ b/src/main/java/ceos/vote/domain/member/entity/Member.java
@@ -36,9 +36,12 @@ public class Member extends BaseEntity {
     @Column(length = 50, nullable = false)
     private TeamType team;
 
+    @Column(name = "vote_back")
     private Boolean voteBack = false;
 
+    @Column(name = "vote_front")
     private Boolean voteFront = false;
 
+    @Column(name = "vote_team")
     private Boolean voteTeam = false;
 }

--- a/src/main/java/ceos/vote/domain/member/entity/Member.java
+++ b/src/main/java/ceos/vote/domain/member/entity/Member.java
@@ -1,6 +1,6 @@
 package ceos.vote.domain.member.entity;
 
-import ceos.vote.global.BaseEntity;
+import ceos.vote.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,6 +16,7 @@ public class Member extends BaseEntity {
     @Column(name = "member_id", nullable = false)
     private Long id;
 
+    // 로그인 아이디
     @Column(name = "user_id", length = 50, nullable = false)
     private String userId;
 
@@ -25,11 +26,13 @@ public class Member extends BaseEntity {
     @Column(length = 320, nullable = false)
     private String email;
 
+    private String role;
+
     @Enumerated(EnumType.STRING)
     @Column(length = 50, nullable = false)
     private PartType part;
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 20, nullable = false)
     private String name;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/ceos/vote/domain/member/entity/Member.java
+++ b/src/main/java/ceos/vote/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package ceos.vote.domain.member.entity;
 
+import ceos.vote.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -8,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ceos/vote/domain/member/entity/Member.java
+++ b/src/main/java/ceos/vote/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package ceos.vote.domain.member.entity;
 import ceos.vote.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -40,11 +41,26 @@ public class Member extends BaseEntity {
     private TeamType team;
 
     @Column(name = "vote_back")
-    private Boolean voteBack = false;
+    private Boolean voteBack;
 
     @Column(name = "vote_front")
-    private Boolean voteFront = false;
+    private Boolean voteFront;
 
     @Column(name = "vote_team")
-    private Boolean voteTeam = false;
+    private Boolean voteTeam;
+
+    @Builder
+    public Member(String userId, String password, String email, String role, PartType part, String name, TeamType team, Boolean voteBack, Boolean voteFront, Boolean voteTeam) {
+
+        this.userId = userId;
+        this.password = password;
+        this.email = email;
+        this.role = role;
+        this.part = part;
+        this.name = name;
+        this.team = team;
+        this.voteBack = voteBack;
+        this.voteFront = voteFront;
+        this.voteTeam = voteTeam;
+    }
 }

--- a/src/main/java/ceos/vote/domain/member/entity/PartType.java
+++ b/src/main/java/ceos/vote/domain/member/entity/PartType.java
@@ -1,6 +1,18 @@
 package ceos.vote.domain.member.entity;
 
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
 public enum PartType {
-    BACKEND,
-    FRONTEND
+
+    BACKEND("백엔드"),
+    FRONTEND("프론트엔드");
+
+    private final String description;
+
+    PartType(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/ceos/vote/domain/member/entity/Refresh.java
+++ b/src/main/java/ceos/vote/domain/member/entity/Refresh.java
@@ -1,0 +1,34 @@
+package ceos.vote.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Refresh {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_id", nullable = false)
+    private Long id;
+
+    @Column(length = 50, nullable = false)
+    private String userId;
+
+    @Column(nullable = false)
+    private String refresh;
+
+    @Column(nullable = false)
+    private String expiration;
+
+    @Builder
+    public Refresh(String userId, String refresh, String expiration) {
+        this.userId = userId;
+        this.refresh = refresh;
+        this.expiration = expiration;
+    }
+}

--- a/src/main/java/ceos/vote/domain/member/entity/TeamType.java
+++ b/src/main/java/ceos/vote/domain/member/entity/TeamType.java
@@ -1,9 +1,21 @@
 package ceos.vote.domain.member.entity;
 
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
 public enum TeamType {
-    PHOTOGROUND,
-    ANGELBRIDGE,
-    PEDALGENIE,
-    CAKEWAY,
-    COFFEEDEAL
+
+    PHOTOGROUND("포토그라운드"),
+    ANGELBRIDGE("엔젤브릿지"),
+    PEDALGENIE("페달지니"),
+    CAKEWAY("케이크웨이"),
+    COFFEEDEAL("커피딜");
+
+    private final String description;
+
+    TeamType(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/ceos/vote/domain/member/service/AuthService.java
+++ b/src/main/java/ceos/vote/domain/member/service/AuthService.java
@@ -159,7 +159,7 @@ public class AuthService {
     @Transactional
     public void deleteAndSaveNewRefreshToken(String userId, String newRefresh, Long expiredMs) {
 
-        refreshRepository.deleteByRefresh(newRefresh);
+        refreshRepository.deleteByUserId(userId);
 
         addRefreshEntity(userId, newRefresh, expiredMs);
     }

--- a/src/main/java/ceos/vote/domain/member/service/AuthService.java
+++ b/src/main/java/ceos/vote/domain/member/service/AuthService.java
@@ -1,0 +1,193 @@
+package ceos.vote.domain.member.service;
+
+import ceos.vote.domain.member.dto.request.SignupRequestDto;
+import ceos.vote.domain.member.dto.response.MemberResponseDto;
+import ceos.vote.domain.member.entity.Member;
+import ceos.vote.domain.member.entity.PartType;
+import ceos.vote.domain.member.entity.Refresh;
+import ceos.vote.domain.member.entity.TeamType;
+import ceos.vote.global.exception.ApplicationException;
+import ceos.vote.global.jwt.JWTUtil;
+import ceos.vote.global.repository.MemberRepository;
+import ceos.vote.global.repository.RefreshRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+import static ceos.vote.global.exception.ExceptionCode.*;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    // [POST] 회원가입
+    @Transactional
+    public MemberResponseDto signup(SignupRequestDto request) {
+
+        String userId = request.userId();
+        String password = request.password();
+
+        if(memberRepository.existsMemberByUserId(userId)){
+            throw new ApplicationException(DUPLICATED_USER_ID);
+        }
+
+        PartType part;
+        TeamType team;
+
+        if (request.part().equals("프론트엔드")) {
+            part = PartType.FRONTEND;
+        } else if (request.part().equals("백엔드")) {
+            part = PartType.BACKEND;
+        } else {
+            throw new ApplicationException(INVALID_PART_TYPE);
+        }
+
+        if (request.team().equals("포토그라운드")) {
+            team = TeamType.PHOTOGROUND;
+        } else if (request.team().equals("엔젤브릿지")) {
+            team = TeamType.ANGELBRIDGE;
+        } else if (request.team().equals("페달지니")) {
+            team = TeamType.PEDALGENIE;
+        } else if (request.team().equals("케이크웨이")) {
+            team = TeamType.CAKEWAY;
+        } else if (request.team().equals("커피딜")) {
+            team = TeamType.COFFEEDEAL;
+        } else {
+            throw new ApplicationException(INVALID_TEAM_TYPE);
+        }
+
+        Member newMember = request.toEntity(bCryptPasswordEncoder.encode(password), part, team);
+
+        memberRepository.save(newMember);
+
+        return MemberResponseDto.from(newMember);
+    }
+
+    /**
+     * Refresh Token 추출
+     * **/
+    public String extractRefreshToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("refreshToken")) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        throw new ApplicationException(NOT_FOUND_REFRESH_TOKEN);
+    }
+
+    /**
+     * Refresh Token 검증
+     * **/
+    public void validateRefreshToken(String refreshToken) {
+
+        try {
+            jwtUtil.isExpired(refreshToken);
+        } catch (ExpiredJwtException e) {
+            throw new ApplicationException(EXPIRED_PERIOD_REFRESH_TOKEN);
+        }
+
+        String category = jwtUtil.getCategory(refreshToken);
+        if (!category.equals("refresh")) {
+            throw new ApplicationException(INVALID_REFRESH_TOKEN);
+        }
+
+        Boolean isExist = refreshRepository.existsByRefresh(refreshToken);
+        if (!isExist) {
+            throw new ApplicationException(INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    /**
+     * Access Token 재발급
+     * **/
+    public String reissueAccessToken(String refreshToken) {
+
+        String userId = jwtUtil.getUsername(refreshToken);
+        String role = jwtUtil.getRole(refreshToken);
+        return jwtUtil.createJwt("access", userId, role, 1000L * 60 * 60 * 24 * 14); // 2주 (임시)
+    }
+
+    /**
+     * 새로운 Refresh Token 생성
+     * **/
+    @Transactional
+    public Cookie createRefreshTokenCookie(String refreshToken) {
+
+        String userId = jwtUtil.getUsername(refreshToken);
+        String role = jwtUtil.getRole(refreshToken);
+        String newRefresh = jwtUtil.createJwt("refresh", userId, role, 1000L * 60 * 60 * 24 * 14);
+
+        if (userId == null) {
+            throw new ApplicationException(FAIL_TO_VALIDATE_TOKEN);
+        }
+
+        deleteAndSaveNewRefreshToken(userId, newRefresh, 1000L * 60 * 60 * 24 * 14);
+
+        return createCookie("refreshToken", newRefresh);
+    }
+
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60 * 60 * 24 * 14);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        // cookie.setSecure(true);
+
+        return cookie;
+    }
+
+    /**
+     * 기존의 Refresh Token 삭제 후 새 Refresh Token 저장
+     **/
+    @Transactional
+    public void deleteAndSaveNewRefreshToken(String userId, String newRefresh, Long expiredMs) {
+
+        refreshRepository.deleteByRefresh(newRefresh);
+
+        addRefreshEntity(userId, newRefresh, expiredMs);
+    }
+
+    /**
+     * 새로운 Refresh Token 저장하는 메서드
+     **/
+    @Transactional
+    public void addRefreshEntity(String userId, String refresh, Long expiredMs) {
+
+        Date expirationDate = new Date(System.currentTimeMillis() + expiredMs);
+
+        Refresh refreshEntity = Refresh.builder()
+                .userId(userId)
+                .refresh(refresh)
+                .expiration(expirationDate.toString())
+                .build();
+
+        refreshRepository.save(refreshEntity);
+    }
+
+    /**
+     * 응답 헤더 및 쿠키 설정
+     * **/
+    public void setNewTokens(HttpServletResponse response, String newAccessToken, Cookie refreshCookie) {
+
+        response.setHeader("Authorization", "Bearer " + newAccessToken);
+
+        response.addCookie(refreshCookie);
+    }
+}

--- a/src/main/java/ceos/vote/domain/member/service/CustomUserDetailsService.java
+++ b/src/main/java/ceos/vote/domain/member/service/CustomUserDetailsService.java
@@ -1,0 +1,32 @@
+package ceos.vote.domain.member.service;
+
+import ceos.vote.domain.member.dto.CustomUserDetails;
+import ceos.vote.domain.member.entity.Member;
+import ceos.vote.global.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+
+        // DB에서 조회
+        Optional<Member> userDataOptional = memberRepository.findByUserId(userId);
+
+        Member userData = userDataOptional.orElseThrow(() ->
+                new UsernameNotFoundException("해당 유저를 찾을 수 없습니다 : " + userId));
+
+        // UserDetails에 담아서 return하면 AuthenticationManager가 검증함
+        return new CustomUserDetails(userData);
+    }
+}

--- a/src/main/java/ceos/vote/domain/member/service/MemberService.java
+++ b/src/main/java/ceos/vote/domain/member/service/MemberService.java
@@ -1,0 +1,31 @@
+package ceos.vote.domain.member.service;
+
+import ceos.vote.domain.member.dto.response.MemberResponseDto;
+import ceos.vote.domain.member.entity.Member;
+import ceos.vote.global.exception.ApplicationException;
+import ceos.vote.global.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static ceos.vote.global.exception.ExceptionCode.NOT_FOUND_USER;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() -> new ApplicationException(NOT_FOUND_USER));
+    }
+
+    // [GET] 회원 기본 정보 조회
+    public MemberResponseDto getMemberInfo(Long memberId) {
+
+        Member member = findMemberById(memberId);
+
+        return MemberResponseDto.from(member);
+    }
+}

--- a/src/main/java/ceos/vote/domain/vote/entity/Vote.java
+++ b/src/main/java/ceos/vote/domain/vote/entity/Vote.java
@@ -1,7 +1,7 @@
 package ceos.vote.domain.vote.entity;
 
 import ceos.vote.domain.member.entity.Member;
-import ceos.vote.global.BaseEntity;
+import ceos.vote.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/ceos/vote/domain/vote/entity/Vote.java
+++ b/src/main/java/ceos/vote/domain/vote/entity/Vote.java
@@ -1,6 +1,7 @@
-package ceos.vote.domain.vote;
+package ceos.vote.domain.vote.entity;
 
 import ceos.vote.domain.member.entity.Member;
+import ceos.vote.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Vote {
+public class Vote extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ceos/vote/domain/vote/entity/Vote.java
+++ b/src/main/java/ceos/vote/domain/vote/entity/Vote.java
@@ -17,7 +17,7 @@ public class Vote extends BaseEntity {
     @Column(name = "vote_id", nullable = false)
     private Long id;
 
-    private int count = 0;
+    private Integer count = 0;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/ceos/vote/global/BaseEntity.java
+++ b/src/main/java/ceos/vote/global/BaseEntity.java
@@ -1,0 +1,28 @@
+package ceos.vote.global;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/ceos/vote/global/common/BaseEntity.java
+++ b/src/main/java/ceos/vote/global/common/BaseEntity.java
@@ -1,4 +1,4 @@
-package ceos.vote.global;
+package ceos.vote.global.common;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/ceos/vote/global/common/response/CommonResponse.java
+++ b/src/main/java/ceos/vote/global/common/response/CommonResponse.java
@@ -1,0 +1,34 @@
+package ceos.vote.global.common.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommonResponse<T> {
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime timestamp;
+    private int code;
+    private String message;
+    private T result;
+
+    // 반환값 있는 경우
+    public CommonResponse(T result, String message) {
+        this.timestamp = LocalDateTime.now();
+        this.code = SuccessCode.SUCCESS.getCode();
+        this.message = message;
+        this.result = result;
+    }
+
+    // 반환값 없는 경우
+    public CommonResponse(String message) {
+        this.timestamp = LocalDateTime.now();
+        this.code = SuccessCode.SUCCESS.getCode();
+        this.message = message;
+    }
+}

--- a/src/main/java/ceos/vote/global/common/response/SuccessCode.java
+++ b/src/main/java/ceos/vote/global/common/response/SuccessCode.java
@@ -1,0 +1,20 @@
+package ceos.vote.global.common.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum SuccessCode {
+
+    SUCCESS(HttpStatus.OK,1000, "요청에 성공하였습니다.");
+
+    private HttpStatus httpStatus;
+    private int code;
+    private String message;
+
+    SuccessCode(HttpStatus httpStatus, int code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/ceos/vote/global/config/CorsMvcConfig.java
+++ b/src/main/java/ceos/vote/global/config/CorsMvcConfig.java
@@ -1,0 +1,19 @@
+package ceos.vote.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowCredentials(true)
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*");
+    }
+}

--- a/src/main/java/ceos/vote/global/config/SecurityConfig.java
+++ b/src/main/java/ceos/vote/global/config/SecurityConfig.java
@@ -1,0 +1,111 @@
+package ceos.vote.global.config;
+
+import ceos.vote.global.jwt.CustomLogoutFilter;
+import ceos.vote.global.jwt.JWTFilter;
+import ceos.vote.global.jwt.JWTUtil;
+import ceos.vote.global.jwt.LoginFilter;
+import ceos.vote.global.repository.MemberRepository;
+import ceos.vote.global.repository.RefreshRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+    private final MemberRepository memberRepository;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .cors((corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {
+
+                    @Override
+                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+
+                        CorsConfiguration configuration = new CorsConfiguration();
+
+                        configuration.setAllowedOrigins(Arrays.asList(
+                                "http://localhost:3000",
+                                "http://localhost:8080",
+                                "http://localhost:8081"
+//                                "http://배포주소:8080",
+//                                "http://배포주소:8081"
+                        ));
+                        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+
+
+                        configuration.setAllowedMethods(Collections.singletonList("*"));
+                        configuration.setAllowCredentials(true);
+                        configuration.setAllowedHeaders(Collections.singletonList("*"));
+                        configuration.setMaxAge(3600L);
+
+                        configuration.setExposedHeaders(Arrays.asList("Set-Cookie", "Authorization"));
+
+                        return configuration;
+                    }
+                })));
+
+        http
+                .csrf((auth) -> auth.disable());
+
+        http
+                .formLogin((auth) -> auth.disable());
+
+        http
+                .httpBasic((auth) -> auth.disable());
+
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/login", "/", "/api/auth/**", "/swagger-ui.html", "/swagger-ui/**","/v3/api-docs/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        http
+                .addFilterBefore(new JWTFilter(jwtUtil, memberRepository), LoginFilter.class);
+        http
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, refreshRepository), UsernamePasswordAuthenticationFilter.class);
+
+        http
+                .addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshRepository), LogoutFilter.class);
+
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/src/main/java/ceos/vote/global/config/SwaggerConfig.java
+++ b/src/main/java/ceos/vote/global/config/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package ceos.vote.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        String jwt = "JWT";
+
+        // Security Requirement와 Security Scheme 설정
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+                .name(jwt)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+        );
+
+        // OpenAPI 객체 반환
+        return new OpenAPI()
+                .components(components)
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement);
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("CEOS 투표 사이트 API") // Swagger 메인 타이틀
+                .description("Ceos 투표 사이트 프-백 과제 API"); // Swagger 설명
+    }
+}

--- a/src/main/java/ceos/vote/global/exception/ApplicationException.java
+++ b/src/main/java/ceos/vote/global/exception/ApplicationException.java
@@ -1,0 +1,11 @@
+package ceos.vote.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApplicationException extends RuntimeException {
+
+    public ExceptionCode exceptionCode;
+}

--- a/src/main/java/ceos/vote/global/exception/ExceptionCode.java
+++ b/src/main/java/ceos/vote/global/exception/ExceptionCode.java
@@ -27,13 +27,16 @@ public enum ExceptionCode {
     WRONG_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, 3002, "유효하지 않은 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, 3003,"올바르지 않은 형식의 RefreshToken 입니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, 3004,"올바르지 않은 형식의 AccessToken 입니다."),
-    DUPLICATED_ADMIN_USERNAME(HttpStatus.BAD_REQUEST, 3005,"중복된 사용자 이름입니다."),
+    DUPLICATED_USER_ID(HttpStatus.BAD_REQUEST, 3005,"중복된 사용자 아이디입니다."),
     DUPLICATED_ADMIN_EMAIL(HttpStatus.BAD_REQUEST, 3006,"중복된 사용자 이메일입니다."),
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, 3007,"존재하지 않는 RefreshToken 입니다."),
     EXPIRED_PERIOD_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 3008,"기한이 만료된 RefreshToken 입니다."),
     EXPIRED_PERIOD_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 3009,"기한이 만료된 AccessToken 입니다."),
     NOT_FOUND_REFRESH_TOKEN_IN_DB(HttpStatus.NOT_FOUND, 3010,"현재 DB에 존재하지 않는 RefreshToken 입니다."),
-    NOT_FOUND_USER(HttpStatus.NOT_FOUND, 3011,"존재하지 않는 사용자입니다.");
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, 3011,"존재하지 않는 사용자입니다."),
+    INVALID_PART_TYPE(HttpStatus.BAD_REQUEST, 3012,"올바르지 않은 형식의 소속 파트입니다."),
+    INVALID_TEAM_TYPE(HttpStatus.BAD_REQUEST, 3013,"올바르지 않은 형식의 소속 팀명입니다."),
+    FAIL_TO_VALIDATE_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, 3014, "토큰 유효성 검사 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/ceos/vote/global/exception/ExceptionCode.java
+++ b/src/main/java/ceos/vote/global/exception/ExceptionCode.java
@@ -1,0 +1,41 @@
+package ceos.vote.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionCode {
+
+    // 1000: Success Case
+
+    // 2000: Common Error
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 2000, "서버 에러가 발생하였습니다. 관리자에게 문의해 주세요."),
+    NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, 2001, "존재하지 않는 리소스입니다."),
+    INVALID_VALUE_EXCEPTION(HttpStatus.BAD_REQUEST, 2002, "올바르지 않은 요청 값입니다."),
+    UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, 2003, "권한이 없는 요청입니다."),
+    ALREADY_DELETE_EXCEPTION(HttpStatus.BAD_REQUEST, 2004, "이미 삭제된 리소스입니다."),
+    FORBIDDEN_EXCEPTION(HttpStatus.FORBIDDEN, 2005, "인가되지 않는 요청입니다."),
+    ALREADY_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST, 2006, "이미 존재하는 리소스입니다."),
+    INVALID_SORT_EXCEPTION(HttpStatus.BAD_REQUEST, 2007, "올바르지 않은 정렬 값입니다."),
+    BAD_REQUEST_ERROR(HttpStatus.BAD_REQUEST, 2008, "잘못된 요청입니다."),
+
+    // 3000: Auth Error
+    KAKAO_TOKEN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, 3000, "토큰 발급에서 오류가 발생했습니다."),
+    KAKAO_USER_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, 3001, "Kakao 프로필 정보를 가져오는 과정에서 오류가 발생했습니다."),
+    WRONG_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, 3002, "유효하지 않은 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, 3003,"올바르지 않은 형식의 RefreshToken 입니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, 3004,"올바르지 않은 형식의 AccessToken 입니다."),
+    DUPLICATED_ADMIN_USERNAME(HttpStatus.BAD_REQUEST, 3005,"중복된 사용자 이름입니다."),
+    DUPLICATED_ADMIN_EMAIL(HttpStatus.BAD_REQUEST, 3006,"중복된 사용자 이메일입니다."),
+    NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, 3007,"존재하지 않는 RefreshToken 입니다."),
+    EXPIRED_PERIOD_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 3008,"기한이 만료된 RefreshToken 입니다."),
+    EXPIRED_PERIOD_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 3009,"기한이 만료된 AccessToken 입니다."),
+    NOT_FOUND_REFRESH_TOKEN_IN_DB(HttpStatus.NOT_FOUND, 3010,"현재 DB에 존재하지 않는 RefreshToken 입니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, 3011,"존재하지 않는 사용자입니다.");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/ceos/vote/global/exception/ExceptionResponse.java
+++ b/src/main/java/ceos/vote/global/exception/ExceptionResponse.java
@@ -1,0 +1,28 @@
+package ceos.vote.global.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record ExceptionResponse (
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime timestamp,
+        int code,
+        String message
+) {
+    // 기본 생성자: exceptionCode만 사용하는 경우
+    public ExceptionResponse(ExceptionCode exceptionCode) {
+        this(LocalDateTime.now(), exceptionCode.getCode(), exceptionCode.getMessage());
+    }
+
+    // 메시지를 직접 지정하는 경우
+    public ExceptionResponse(String message) {
+        this(LocalDateTime.now(), ExceptionCode.INTERNAL_SERVER_ERROR.getCode(), message);
+    }
+
+    // exceptionCode와 메시지를 동시에 사용하는 경우
+    public ExceptionResponse(ExceptionCode exceptionCode, String message) {
+        this(LocalDateTime.now(), exceptionCode.getCode(), message);
+    }
+}

--- a/src/main/java/ceos/vote/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ceos/vote/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package ceos.vote.global.exception;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
+
+import static ceos.vote.global.exception.ExceptionCode.INTERNAL_SERVER_ERROR;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApplicationException.class)
+    protected ResponseEntity<ExceptionResponse> handleBadRequestException(ApplicationException e){
+
+        log.error("BadRequestException 발생: {}", e.getMessage(), e);
+
+        return ResponseEntity.status(e.getExceptionCode().getHttpStatus())
+                .body(new ExceptionResponse(e.getExceptionCode()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> methodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        log.error("MethodArgumentNotValidException 발생: {}", e.getMessage(), e);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ExceptionResponse(ExceptionCode.INVALID_VALUE_EXCEPTION, Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleException(final Exception e){
+
+        log.error("UnhandledException 발생: {}", e.getMessage(), e);
+
+        return ResponseEntity.internalServerError()
+                .body(new ExceptionResponse(INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/ceos/vote/global/jwt/CustomLogoutFilter.java
+++ b/src/main/java/ceos/vote/global/jwt/CustomLogoutFilter.java
@@ -1,0 +1,99 @@
+package ceos.vote.global.jwt;
+
+import ceos.vote.global.exception.ApplicationException;
+import ceos.vote.global.repository.RefreshRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+import static ceos.vote.global.exception.ExceptionCode.*;
+
+@RequiredArgsConstructor
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        String requestUri = request.getRequestURI();
+        if (!requestUri.matches("^\\/logout$")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String requestMethod = request.getMethod();
+        if (!requestMethod.equals("POST")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+
+            if (cookie.getName().equals("refreshToken")) {
+
+                refresh = cookie.getValue();
+            }
+        }
+
+        if (refresh == null) {
+
+            throw new ApplicationException(NOT_FOUND_REFRESH_TOKEN);
+        }
+
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+
+            throw new ApplicationException(EXPIRED_PERIOD_REFRESH_TOKEN);
+        }
+
+        String category = jwtUtil.getCategory(refresh);
+        if (!category.equals("refresh")) {
+
+            throw new ApplicationException(INVALID_REFRESH_TOKEN);
+        }
+
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if (!isExist) {
+
+            throw new ApplicationException(NOT_FOUND_REFRESH_TOKEN_IN_DB);
+        }
+
+        /**
+         * [ 로그아웃 진행 ]
+         * **/
+
+        // Refresh 토큰 DB에서 제거
+        refreshRepository.deleteByRefresh(refresh);
+
+        //Refresh 토큰 Cookie 값 0
+        Cookie cookie = new Cookie("refreshToken", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("{\"result\": \"로그아웃이 성공적으로 완료되었습니다.\"}");
+    }
+}

--- a/src/main/java/ceos/vote/global/jwt/JWTFilter.java
+++ b/src/main/java/ceos/vote/global/jwt/JWTFilter.java
@@ -1,0 +1,74 @@
+package ceos.vote.global.jwt;
+
+import ceos.vote.domain.member.dto.CustomUserDetails;
+import ceos.vote.domain.member.entity.Member;
+import ceos.vote.global.repository.MemberRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@RequiredArgsConstructor
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+    private final MemberRepository memberRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken = header.substring(7); // "Bearer " 제거 후 토큰만 추출
+
+        // 토큰 만료 여부 확인, 만료 시 다음 필터로 넘기지 않음
+        try {
+            jwtUtil.isExpired(accessToken);
+        } catch (ExpiredJwtException e) {
+
+            PrintWriter writer = response.getWriter();
+            writer.print("AccessToken이 만료되었습니다.");
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        // 토큰이 access 인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(accessToken);
+
+        if (!category.equals("access")) {
+
+            PrintWriter writer = response.getWriter();
+            writer.print("유효하지 않은 AccessToken 입니다.");
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        String userId = jwtUtil.getUsername(accessToken);
+
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다."));
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(member);
+
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/ceos/vote/global/jwt/JWTUtil.java
+++ b/src/main/java/ceos/vote/global/jwt/JWTUtil.java
@@ -1,0 +1,53 @@
+package ceos.vote.global.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    private SecretKey secretKey;
+
+    public JWTUtil(@Value("${spring.jwt.secret}") String secret) {
+
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getUsername(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userId", String.class);
+    }
+
+    public String getRole(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public String getCategory(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String category, String userId, String role, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("category", category)
+                .claim("userId", userId)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))                 // 발급 시간
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))   // 만료 시간
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/ceos/vote/global/jwt/LoginFilter.java
+++ b/src/main/java/ceos/vote/global/jwt/LoginFilter.java
@@ -1,0 +1,120 @@
+package ceos.vote.global.jwt;
+
+import ceos.vote.domain.member.dto.request.LoginRequestDto;
+import ceos.vote.domain.member.entity.Refresh;
+import ceos.vote.global.repository.RefreshRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+
+@RequiredArgsConstructor
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+        LoginRequestDto loginRequestDto;
+
+        try {
+            // JSON 요청 본문을 읽어 LoginRequestDto 객체로 변환
+            ServletInputStream inputStream = request.getInputStream();
+            String messageBody = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+            loginRequestDto = objectMapper.readValue(messageBody, LoginRequestDto.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        String userId = loginRequestDto.userId();
+        String password = loginRequestDto.password();
+
+        // 스프링 시큐리티에서 userId와 password를 검증하기 위해서는 token(dto)에 담아야 함
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userId, password, null);
+
+        // token에 담은 값들의 검증을 위해 AuthenticationManager로 전달 -> 검증 진행
+        return authenticationManager.authenticate(authToken);
+    }
+
+    // 로그인 성공 시 실행하는 메소드 (JWT 발급)
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException {
+
+        String nickname = authentication.getName();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+
+        //토큰 생성
+        String access = jwtUtil.createJwt("access", nickname, role, 1000L * 60 * 60 * 24 * 14);           // 2주 (임시)
+        String refresh = jwtUtil.createJwt("refresh", nickname, role, 1000L * 60 * 60 * 24 * 14);   // 2주
+
+        //Refresh 토큰 저장
+        addRefreshEntity(nickname, refresh, 1000L * 60 * 60 * 24 * 14);
+
+        //응답 설정
+        response.setHeader("Authorization", "Bearer " + access);
+        response.addCookie(createCookie("refreshToken", refresh));
+        response.setStatus(HttpStatus.OK.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("{\"result\": \"로그인이 성공적으로 완료되었습니다.\"}");
+    }
+
+    //로그인 실패시 실행하는 메소드
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
+
+        response.setStatus(401);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("{\"result\": \"로그인에 실패하였습니다.\"}");
+    }
+
+    private void addRefreshEntity(String userId, String refresh, Long expiredMs) {
+
+        Date date = new Date(System.currentTimeMillis() + expiredMs);
+
+        Refresh refreshEntity = Refresh.builder()
+                .userId(userId)
+                .refresh(refresh)
+                .expiration(date.toString())
+                .build();
+
+        refreshRepository.save(refreshEntity);
+    }
+
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60 * 60 * 24 * 14);
+        //cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/src/main/java/ceos/vote/global/repository/MemberRepository.java
+++ b/src/main/java/ceos/vote/global/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package ceos.vote.global.repository;
+
+import ceos.vote.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByUserId(String userId);
+
+    Boolean existsMemberByUserId(String userId);
+}

--- a/src/main/java/ceos/vote/global/repository/RefreshRepository.java
+++ b/src/main/java/ceos/vote/global/repository/RefreshRepository.java
@@ -10,4 +10,7 @@ public interface RefreshRepository extends JpaRepository<Refresh, String> {
 
     @Transactional
     void deleteByRefresh(String refresh);
+
+    @Transactional
+    void deleteByUserId(String userId);
 }

--- a/src/main/java/ceos/vote/global/repository/RefreshRepository.java
+++ b/src/main/java/ceos/vote/global/repository/RefreshRepository.java
@@ -1,0 +1,13 @@
+package ceos.vote.global.repository;
+
+import ceos.vote.domain.member.entity.Refresh;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface RefreshRepository extends JpaRepository<Refresh, String> {
+
+    Boolean existsByRefresh(String refresh);
+
+    @Transactional
+    void deleteByRefresh(String refresh);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=vote


### PR DESCRIPTION
## API 구현
1. 로그인, 로그아웃, 토큰재발급 API 구현 완료
2. accessToken 과 refreshToken 발급 로직 구현 완료
3. [GET] 회원 기본 정보 조회 API 구현 완료

## 환경설정
1. swagger 기본 설정 및 환경 설정 완료
2. cors 설정 완료
3. enum 파일 description 추가 완료
4. 공통응답코드 (성공, 에러 코드) 설정 완료
5. BaseEntity 설정 완료
6. build.gradle에 `sql` import 완료
7. gitignore에 yml 파일 등록 완료